### PR TITLE
Compare .csv read functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,27 +11,16 @@ We run the selected function 1000 times over one column using [microbenchmark R 
 ## Performance Result
 
 
-### subset functions
+### load csv functions
 
-Subset column in dataframe
-
-function | times | unit | lq | uq | min | max | median | avg
---- | --- | --- | --- | --- | --- | --- | --- | ---
-base1 | 1000 | ms | 0.046 | 0.070 | 0.029 |   7.155 | 0.051 | 0.069
-base2 | 1000 | ms | 0.046 | 0.070 | 0.028 |   0.719 | 0.051 | 0.062
-select | 1000 | ms | 3.026 | 3.385 | 2.300 | 171.330 | 3.163 | 3.603
-
-### to string functions
-
-Convert column as character
+Load a .csv file into an R object (data frame/tibble/etc.)
 
 function | times | unit | lq | uq | min | max | median | avg
 --- | --- | --- | --- | --- | --- | --- | --- | ---
-as.character | 1000 | ms |  9.294 |  9.561 |  8.753 |  26.156 |  9.417 |  9.670
-formatC | 1000 | ms | 18.431 | 20.064 | 17.091 | 149.821 | 18.836 | 20.896
-paste | 1000 | ms | 14.372 | 14.779 | 13.418 |  32.034 | 14.562 | 14.937
-toString | 1000 | ms | 16.637 | 17.086 | 15.707 |  41.926 | 16.866 | 17.279
-sprintf | 1000 | ms | 17.489 | 17.929 | 16.577 |  44.356 | 17.697 | 18.154
+fread | 100 | ms |  38.250 |  52.078 |  37.182 |  244.789 |  41.062 |  48.074
+import | 100 | ms |  39.385 |  55.187 |  38.124 |   92.511 |  46.186 |  49.661
+read.csv | 100 | ms | 508.648 | 585.146 | 488.136 | 1173.685 | 532.987 | 570.243
+read_csv | 100 | ms | 161.373 | 191.777 | 133.286 |  678.702 | 173.806 | 189.244
 
 ### mapping functions
 
@@ -39,20 +28,10 @@ Apply a specific function to a list or vector.
 
 function | times | unit | lq | uq | min | max | median | avg
 --- | --- | --- | --- | --- | --- | --- | --- | ---
-lapply | 1000 | ms | 24.797 | 36.303 | 21.462 | 177.460 | 25.461 | 29.437
-sapply | 1000 | ms | 45.477 | 57.340 | 41.955 | 191.467 | 46.537 | 50.650
-map | 1000 | ms | 59.256 | 71.623 | 54.824 | 216.958 | 69.014 | 69.942
-map_chr | 1000 | ms | 60.548 | 70.826 | 49.809 | 228.917 | 68.514 | 69.210
-
-### to date functions
-
-Convert column to date format
-
-function | times | unit | lq | uq | min | max | median | avg
---- | --- | --- | --- | --- | --- | --- | --- | ---
-lubridate | 1000 | ms | 15.960 | 25.373 | 15.044 | 149.830 | 17.809 | 22.262
-to.date | 1000 | ms | 26.657 | 28.798 | 24.899 | 160.471 | 26.957 | 30.054
-strptime | 1000 | ms | 80.131 | 82.893 | 77.475 | 346.436 | 81.040 | 84.660
+lapply | 1000 | ms | 12.205 | 13.952 | 11.714 | 212.913 | 12.494 | 14.894
+sapply | 1000 | ms | 15.154 | 17.356 | 14.404 |  56.467 | 15.541 | 17.657
+map | 1000 | ms | 26.620 | 37.616 | 25.654 | 223.574 | 28.354 | 33.111
+map_chr | 1000 | ms | 27.417 | 38.271 | 26.093 | 225.453 | 29.188 | 33.753
 
 ### simple pattern matching functions
 
@@ -60,9 +39,41 @@ Find a simple pattern in a string, and return the subset
 
 function | times | unit | lq | uq | min | max | median | avg
 --- | --- | --- | --- | --- | --- | --- | --- | ---
-grep | 1000 | ms |  15.600 |  16.477 |  14.167 |  33.731 |  16.051 |  16.171
-regexpr | 1000 | ms |  20.181 |  21.236 |  18.470 | 158.691 |  20.637 |  21.587
-sqldf | 1000 | ms | 206.089 | 215.534 | 197.608 | 351.085 | 209.091 | 211.285
+grep | 1000 | ms |   5.233 |   5.947 |   4.837 |  34.422 |   5.447 |   6.096
+regexpr | 1000 | ms |   8.224 |   9.052 |   7.715 |  52.361 |   8.467 |   9.568
+sqldf | 1000 | ms | 118.596 | 133.969 | 114.072 | 461.028 | 121.131 | 137.014
+
+### subset functions
+
+Subset column in dataframe
+
+function | times | unit | lq | uq | min | max | median | avg
+--- | --- | --- | --- | --- | --- | --- | --- | ---
+base1 | 1000 | ms | 0.017 | 0.033 | 0.015 |  0.105 | 0.021 | 0.026
+base2 | 1000 | ms | 0.017 | 0.032 | 0.015 |  0.203 | 0.021 | 0.026
+select | 1000 | ms | 1.506 | 1.637 | 1.432 | 33.489 | 1.554 | 1.704
+
+### to date functions
+
+Convert column to date format
+
+function | times | unit | lq | uq | min | max | median | avg
+--- | --- | --- | --- | --- | --- | --- | --- | ---
+lubridate | 1000 | ms |   7.370 |   9.153 |   6.963 | 202.276 |   7.705 |   9.787
+to.date | 1000 | ms |  14.633 |  16.840 |  14.011 |  57.368 |  15.083 |  17.058
+strptime | 1000 | ms | 212.153 | 236.698 | 205.226 | 464.125 | 216.453 | 234.386
+
+### to string functions
+
+Convert column as character
+
+function | times | unit | lq | uq | min | max | median | avg
+--- | --- | --- | --- | --- | --- | --- | --- | ---
+as.character | 1000 | ms |  0.028 |  0.045 |  0.006 |  10.563 |  0.038 |  0.048
+formatC | 1000 | ms | 13.551 | 14.481 | 12.711 |  62.413 | 13.822 | 15.167
+paste | 1000 | ms | 14.609 | 15.289 | 14.030 | 207.284 | 14.801 | 16.277
+toString | 1000 | ms | 16.162 | 16.837 | 15.549 |  58.643 | 16.381 | 17.780
+sprintf | 1000 | ms | 18.049 | 18.847 | 17.456 |  58.991 | 18.274 | 19.786
 
 ## License
 

--- a/src/analysis_load_csv.R
+++ b/src/analysis_load_csv.R
@@ -1,0 +1,12 @@
+description <- "Load a .csv file into an R object (data frame/tibble/etc.)"
+
+# Microbenchmark
+mb <- microbenchmark(
+	fread = fread("./data/Melbourne_housing_FULL.csv"),
+	import = import("./data/Melbourne_housing_FULL.csv"),
+	read.csv = read.csv("./data/Melbourne_housing_FULL.csv"),
+	read_csv = read_csv("./data/Melbourne_housing_FULL.csv")
+)
+
+# Print markdown table
+paste("\n### load csv functions\n", description, "", to_markdown(mb), sep = "\n")

--- a/src/main.R
+++ b/src/main.R
@@ -12,6 +12,7 @@ library(dplyr)
 library(purrr)
 library(lubridate)
 library(sqldf)
+library(rio)
 source("./utils/to_markdown.R")
 
 # Get data
@@ -22,11 +23,12 @@ r <- read.csv(
 
 # Call analysed functions and append to results vector
 analysed_results <- "" %>%
-	append(source("./src/analysis_subset.R")$value) %>%
-	append(source("./src/analysis_to_string.R")$value) %>%
+	append(source("./src/analysis_load_csv.R")$value) %>%
 	append(source("./src/analysis_mapping.R")$value) %>%
-	append(source("./src/analysis_to_date.R")$value) %>%
 	append(source("./src/analysis_simple_pattern_matching.R")$value) %>%
+	append(source("./src/analysis_subset.R")$value) %>%
+	append(source("./src/analysis_to_date.R")$value) %>%
+	append(source("./src/analysis_to_string.R")$value) %>%
 	append("")
 
 # Open readme read + write


### PR DESCRIPTION
### Description
Added a comparison of a few different methods of importing a .csv file. These different methods may create different object classes (i.e. read.csv gives a data frame, read_csv a tibble). Could fix by wrapping things in as.tibble() or as.data.frame() as needed if desired.

### Improvement
Was curious to see which method was fastest since reading .csv's is so essentially to so many data analysis projects.